### PR TITLE
ES6 fix

### DIFF
--- a/write.js
+++ b/write.js
@@ -24,7 +24,7 @@ class ChunkStoreWriteStream extends stream.Writable {
       .on('data', onData)
       .on('error', err => { this.destroy(err) })
 
-    this.on('finish', this._blockstream.end)
+    this.on('finish', () => this._blockstream.end())
   }
 
   _write (chunk, encoding, callback) {


### PR DESCRIPTION
Function hoisting is breaking WebTorrent build, see https://github.com/webtorrent/webtorrent/issues/1481.

Also makes better use of params defaults, arrow functions, etc.