### PR TITLE
Add support for additional options

### DIFF
--- a/read.js
+++ b/read.js
@@ -13,21 +13,34 @@ class ChunkStoreReadStream extends stream.Readable {
     this._length = opts.length || store.length
     if (!Number.isFinite(this._length)) throw new Error('missing required `length` property')
 
+    const offset = opts.offset || 0
+
     this._store = store
     this._chunkLength = chunkLength
-    this._index = 0
+    this._index = Math.floor(offset / chunkLength)
+    this._chunkOffset = offset % chunkLength
+    this._consumedLength = 0
   }
 
   _read () {
-    if (this._index * this._chunkLength >= this._length) {
+    const remainingLength = this._length - this._consumedLength
+    if (remainingLength <= 0) {
       this.push(null)
     } else {
-      this._store.get(this._index, (err, chunk) => {
+      const offset = this._chunkOffset
+      const length = Math.min(remainingLength, this._chunkLength - this._chunkOffset)
+      this._chunkOffset = 0
+      this._consumedLength += length
+
+      this._store.get(this._index, {
+        offset,
+        length
+      }, (err, chunk) => {
         if (err) return this.destroy(err)
         this.push(chunk)
       })
+      this._index += 1
     }
-    this._index += 1
   }
 
   destroy (err) {

--- a/write.js
+++ b/write.js
@@ -11,7 +11,8 @@ class ChunkStoreWriteStream extends stream.Writable {
     chunkLength = Number(chunkLength)
     if (!chunkLength) throw new Error('Second argument must be a chunk length')
 
-    this._blockstream = new BlockStream(chunkLength, { zeroPadding: false })
+    const zeroPadding = opts.zeroPadding === undefined ? false : opts.zeroPadding
+    this._blockstream = new BlockStream(chunkLength, { zeroPadding })
     this._outstandingPuts = 0
 
     let index = 0
@@ -19,7 +20,8 @@ class ChunkStoreWriteStream extends stream.Writable {
       if (this.destroyed) return
 
       this._outstandingPuts += 1
-      store.put(index, chunk, () => {
+      store.put(index, chunk, (err) => {
+        if (err) return this.destroy(err)
         this._outstandingPuts -= 1
         if (this._outstandingPuts === 0 && typeof this._finalCb === 'function') {
           this._finalCb(null)


### PR DESCRIPTION
* opts.offset in read stream
* opts.length now handles non-chunk-size lengths in read stream
* opts.zeroPadding in write stream

Also, catch the error passed to the callback to `store.put`